### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
     code-quality:
         name: Code Quality
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
         strategy:
             matrix:
                 node-version: [20] # Use single version for quality checks
@@ -64,6 +66,8 @@ jobs:
     test:
         name: Test Suite
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
         strategy:
             matrix:
                 node-version: [20, 22, 24]


### PR DESCRIPTION
Potential fix for [https://github.com/kakiii/kmatch/security/code-scanning/1](https://github.com/kakiii/kmatch/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for each job. For example:
- The `code-quality` job only needs `contents: read` to check out the code.
- The `test` job also requires `contents: read` for code checkout and artifact upload.
- Other jobs should similarly have their permissions explicitly defined based on their requirements.

The `permissions` block can be added at the workflow level (to apply to all jobs) or at the job level (to customize permissions for each job). In this case, adding permissions at the job level provides better granularity.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
